### PR TITLE
Bugfix: BGC-127 change flow of help request to postEphemeral

### DIFF
--- a/app/org/catalyst/slackservice/services/AppService.java
+++ b/app/org/catalyst/slackservice/services/AppService.java
@@ -1,10 +1,7 @@
 package org.catalyst.slackservice.services;
 
 import org.catalyst.slackservice.db.Bot;
-import org.catalyst.slackservice.domain.AuthResponse;
-import org.catalyst.slackservice.domain.Event;
-import org.catalyst.slackservice.domain.InteractiveMessage;
-import org.catalyst.slackservice.domain.SlackResponse;
+import org.catalyst.slackservice.domain.*;
 import org.catalyst.slackservice.util.SlackLocale;
 import org.catalyst.slackservice.util.MessageHandler;
 
@@ -29,4 +26,6 @@ public interface AppService {
     CompletionStage<SlackResponse> postHelpMessage(MessageHandler messages, Event event, Bot bot);
 
     CompletionStage<SlackLocale> getConversationLocale(String channel, Bot bot);
+
+    CompletionStage<SlackResponse> postCustomMessage(String url, Message message, Bot bot);
 }

--- a/app/org/catalyst/slackservice/services/SlackService.java
+++ b/app/org/catalyst/slackservice/services/SlackService.java
@@ -81,11 +81,10 @@ public class SlackService implements AppService, WSBodyReadables {
 
     @Override
     public CompletionStage<SlackResponse> postReauthMessage(final MessageHandler messages, final Event event, final Bot bot) {
-        String url = _config.getPostEphemeralUrl();
         Message message = MessageGenerator.generatePluginAddedMessage(messages, event,
                 bot.token, _config.getAppSigninUrl(), _config.getLearnMoreUrl());
         message.user = event.user;
-        return postReply(url, message, bot.token);
+        return postReply(_config.getPostEphemeralUrl(), message, bot.token);
     }
 
     @Override
@@ -169,5 +168,12 @@ public class SlackService implements AppService, WSBodyReadables {
             logger.debug("user locale " + localeCode);
             return new SlackLocale(localeCode);
         } , _ec.current());
+    }
+
+    @Override
+    public CompletionStage<SlackResponse> postCustomMessage(String url, Message message, Bot bot) {
+        message.token = bot.token;
+
+        return postReply(url, message, message.token);
     }
 }

--- a/test/org/catalyst/slackservice/controllers/HelpControllerTest.java
+++ b/test/org/catalyst/slackservice/controllers/HelpControllerTest.java
@@ -11,17 +11,14 @@ import org.junit.Before;
 import org.junit.Test;
 import play.Application;
 import play.inject.guice.GuiceApplicationBuilder;
-import play.libs.Json;
 import play.mvc.Http;
 import play.test.WithApplication;
 
 import java.util.HashMap;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static play.inject.Bindings.bind;
 import static play.mvc.Http.Status.NO_CONTENT;
-import static play.mvc.Http.Status.OK;
 import static play.test.Helpers.*;
 
 public class HelpControllerTest extends WithApplication {
@@ -78,11 +75,7 @@ public class HelpControllerTest extends WithApplication {
                 .uri(URI).bodyFormArrayValues(requestBody);
 
         var result = route(app, request);
-        var body = contentAsBytes(result).toArray();
-        var text = Json.parse(body).path("text").textValue();
-
-        assertTrue(text.indexOf("random") > -1);
-        assertEquals(OK, result.status());
+        assertEquals(NO_CONTENT, result.status());
     }
 
     @Test
@@ -94,23 +87,19 @@ public class HelpControllerTest extends WithApplication {
                 .uri(URI).bodyFormArrayValues(requestBody);
 
         var result = route(app, request);
-        var body = contentAsBytes(result).toArray();
-        var text = Json.parse(body).path("text").textValue();
-
-        assertTrue(text.indexOf("No action specified") > -1);
-        assertEquals(OK, result.status());
+        assertEquals(NO_CONTENT, result.status());
     }
 
     @Test
     public void testHelpContent() {
         var requestBody = getValidHelpRequest();
         var request = new Http.RequestBuilder()
-                .header("X-Slack-Signature", "v0=7b6a6fb122a9ee3783fb2ab0bbe356eb8523ca706547547f6b410fba0112dd79")
+                .header("X-Slack-Signature", "v0=cef2363a542926cc08ff21307a25a9a1f08503333664f8259d79ae99aa582a19")
                 .header("X-Slack-Request-Timestamp", "1578867626")
                 .method(POST)
                 .uri(URI).bodyFormArrayValues(requestBody);
         var result = route(app, request);
-        assertEquals(OK, result.status());
+        assertEquals(NO_CONTENT, result.status());
     }
 
     @Test
@@ -142,6 +131,7 @@ public class HelpControllerTest extends WithApplication {
         requestBody.put("text", new String[]{"help"});
         requestBody.put("channel_id", new String[]{"valid_channel_123"});
         requestBody.put("team_id", new String[]{"TEAM123"});
+        requestBody.put("user_id", new String[]{"USER123"});
         return requestBody;
     }
 }

--- a/test/org/catalyst/slackservice/services/MockSlackService.java
+++ b/test/org/catalyst/slackservice/services/MockSlackService.java
@@ -1,10 +1,7 @@
 package org.catalyst.slackservice.services;
 
 import org.catalyst.slackservice.db.Bot;
-import org.catalyst.slackservice.domain.AuthResponse;
-import org.catalyst.slackservice.domain.Event;
-import org.catalyst.slackservice.domain.InteractiveMessage;
-import org.catalyst.slackservice.domain.SlackResponse;
+import org.catalyst.slackservice.domain.*;
 import org.catalyst.slackservice.util.MessageHandler;
 import org.catalyst.slackservice.util.SlackLocale;
 
@@ -98,5 +95,13 @@ public class MockSlackService implements AppService {
     @Override
     public CompletionStage<SlackLocale> getConversationLocale(String channel, Bot bot) {
         return CompletableFuture.completedFuture(new SlackLocale());
+    }
+
+    @Override
+    public CompletionStage<SlackResponse> postCustomMessage(String url, Message message, Bot bot) {
+        var response = new SlackResponse();
+        response.ok = true;
+        response.messageTs = "45678.90123";
+        return CompletableFuture.completedFuture(response);
     }
 }

--- a/test/org/catalyst/slackservice/services/SlackServiceTest.java
+++ b/test/org/catalyst/slackservice/services/SlackServiceTest.java
@@ -313,4 +313,33 @@ public class SlackServiceTest {
         }
     }
 
+    @Test
+    public void testPostReauthorization() throws Exception {
+        var event = new Event();
+        event.ts = "valid_callback_id";
+        event.channel = "valid_channel";
+        event.user = "USER123";
+
+        var response = service.postReauthMessage(msg, event, bot)
+                .toCompletableFuture()
+                .get(10, TimeUnit.SECONDS);
+
+        Assert.assertEquals(true, response.ok);
+        Assert.assertEquals(EPHEMERAL_TS, response.messageTs);
+    }
+
+    @Test
+    public void testPostCustomMessage() throws Exception {
+        var message = new Message();
+        message.channel = "valid_channel";
+        message.user = "USER123";
+        message.text = "text";
+
+        var response = service.postCustomMessage(config.getPostEphemeralUrl(), message, bot)
+                .toCompletableFuture()
+                .get(10, TimeUnit.SECONDS);
+
+        Assert.assertEquals(true, response.ok);
+        Assert.assertEquals(EPHEMERAL_TS, response.messageTs);
+    }
 }


### PR DESCRIPTION
For consistency with displaying sender name without the hashtag, we'll need to use the bot auth token for all actions