### PR TITLE
Bugfix: BGC-122 delete db user_tokens value for user if their slack token was revoked

### DIFF
--- a/app/org/catalyst/slackservice/db/RedisDbHandler.java
+++ b/app/org/catalyst/slackservice/db/RedisDbHandler.java
@@ -12,6 +12,7 @@ import javax.inject.Inject;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
 
 public class RedisDbHandler implements TokenHandler, AnalyticsHandler {
     final Logger logger = LoggerFactory.getLogger(RedisDbHandler.class);
@@ -100,6 +101,21 @@ public class RedisDbHandler implements TokenHandler, AnalyticsHandler {
 
         logger.debug("bot info for {} {}", teamId, ((bot == null) ? "not found" : "found"));
         return bot;
+    }
+
+    @Override
+    public void deleteTokens(String teamId, String[] tokens) {
+        if (teamId == null || tokens == null || tokens.length == 0) {
+            logger.error("unable to delete tokens for team {}. token null? {}", teamId, tokens == null);
+            return;
+        }
+
+        String[] newTokens = Arrays.stream(tokens).map(token -> format(teamId, token)).toArray(String[]::new);
+
+        try (Jedis jedis = _jedisPool.getResource()) {
+            logger.debug("deleting tokens {}", Arrays.asList(newTokens));
+            jedis.hdel( USER_TOKENS, newTokens);
+        }
     }
 
     @Override

--- a/app/org/catalyst/slackservice/db/TokenHandler.java
+++ b/app/org/catalyst/slackservice/db/TokenHandler.java
@@ -6,4 +6,5 @@ public interface TokenHandler {
 
     void setBotInfo(String teamId, Bot bot);
     Bot getBotInfo(String teamId);
+    void deleteTokens(String teamId, String[] tokens);
 }

--- a/app/org/catalyst/slackservice/domain/Event.java
+++ b/app/org/catalyst/slackservice/domain/Event.java
@@ -23,4 +23,9 @@ public class Event {
     public String channelType;
     @JsonProperty("thread_ts")
     public String threadTs;
+    public Tokens tokens;
+    public static class Tokens {
+        public String[] oauth;
+        public String[] bot;
+    }
 }

--- a/test/org/catalyst/slackservice/controllers/EventControllerTest.java
+++ b/test/org/catalyst/slackservice/controllers/EventControllerTest.java
@@ -261,7 +261,7 @@ public class EventControllerTest extends WithApplication {
         eventRequest.event.text = "she's so quiet";
 
         var httpRequest = new Http.RequestBuilder()
-                .header("X-Slack-Signature", "v0=6dedc3a067ddd9c4c93cf4ca6e3ab2cfcc56d89fb85d02c153c81b3b2e8d35f1")
+                .header("X-Slack-Signature", "v0=679bf0a68c77b007a7d50aa4eb7df46c763c2c16153e551a70cd213380f149e7")
                 .header("X-Slack-Request-Timestamp", "1578867626")
                 .method(POST)
                 .uri(EVENTS_URI).bodyJson(Json.toJson(eventRequest));
@@ -283,7 +283,7 @@ public class EventControllerTest extends WithApplication {
         eventRequest.token = null;
 
         var httpRequest = new Http.RequestBuilder()
-                .header("X-Slack-Signature", "v0=2bcd1287bd7880367967d133c9693f5ea9d769b839ea4f6e9572578b8980dda0")
+                .header("X-Slack-Signature", "v0=679bf0a68c77b007a7d50aa4eb7df46c763c2c16153e551a70cd213380f149e7")
                 .header("X-Slack-Request-Timestamp", "1578867626")
                 .method(POST)
                 .uri(EVENTS_URI).bodyJson(Json.toJson(eventRequest));
@@ -359,6 +359,27 @@ public class EventControllerTest extends WithApplication {
 
         var result = route(app, httpRequest);
         assertEquals(OK, result.status());
+    }
+
+    @Test
+    public void testRevokeTokens() {
+        var event = new Event();
+        var eventRequest = new EventController.Request();
+        eventRequest.token = "valid_token_123";
+        eventRequest.type = "event_callback";
+        eventRequest.teamId = "new_team_234";
+        eventRequest.event = event;
+
+        event.type = "tokens_revoked";
+        event.tokens = new Event.Tokens();
+        event.tokens.oauth = new String[]{"revoked_user_123", "revoked_user_234"};
+
+        var httpRequest = new Http.RequestBuilder()
+                .method(POST)
+                .uri(EVENTS_URI).bodyJson(Json.toJson(eventRequest));
+
+        var result = route(app, httpRequest);
+        assertEquals(NO_CONTENT, result.status());
     }
 
     private static EventController.Request getValidEventCallback() {

--- a/test/org/catalyst/slackservice/db/MockDbHandler.java
+++ b/test/org/catalyst/slackservice/db/MockDbHandler.java
@@ -71,4 +71,15 @@ public class MockDbHandler implements TokenHandler, AnalyticsHandler {
         } catch (JsonProcessingException e) {}
         return bot;
     }
+
+    @Override
+    public void deleteTokens(String teamId, String[] tokens) {
+        if (teamId == null || tokens == null || tokens.length == 0) {
+            return;
+        }
+
+        for (String token: tokens) {
+            _userTokens.remove(String.format("%s_%s", teamId, token));
+        }
+    }
 }


### PR DESCRIPTION
we need to make the behavior consistent between slack revoked tokens and our db tokens. Deleting the db token if the token was revoked on slack