### PR TITLE
Add custom dimension fields for analytics

### DIFF
--- a/app/org/catalyst/slackservice/controllers/AuthController.java
+++ b/app/org/catalyst/slackservice/controllers/AuthController.java
@@ -70,10 +70,8 @@ public class AuthController extends Controller {
                         "error", response.error))));
             }
 
-            if (BOT_TOKEN_TYPE.equals(response.tokenType) && response.botUserId != null && response.accessToken != null) {
-                var bot = new Bot();
-                bot.token = response.accessToken;
-                bot.userId = response.botUserId;
+            if (BOT_TOKEN_TYPE.equals(response.tokenType) && response.botUserId != null && response.accessToken != null && response.team != null) {
+                var bot = new Bot(response.accessToken, response.botUserId, response.team.name);
                 _tokenDb.setBotInfo(teamId, bot);
             }
 

--- a/app/org/catalyst/slackservice/controllers/EventController.java
+++ b/app/org/catalyst/slackservice/controllers/EventController.java
@@ -187,7 +187,7 @@ public class EventController extends Controller {
     }
 
     private CompletionStage<Result> handleUserMessage(final MessageHandler messages, final Event event, final Bot bot) {
-        var key = new AnalyticsKey(_config.getTrackingId(), event.channel, event.user);
+        var key = new AnalyticsKey(_config.getTrackingId(), event.team, bot.teamName, event.channel, event.user, messages.slackLocale);
         var correctorResult = _biasCorrector.getCorrection(event.text, messages.slackLocale);
         return correctorResult.thenComposeAsync(correction -> {
             _analyticsService.track(AnalyticsEvent.createMessageEvent(key, correction));

--- a/app/org/catalyst/slackservice/db/Bot.java
+++ b/app/org/catalyst/slackservice/db/Bot.java
@@ -1,6 +1,17 @@
 package org.catalyst.slackservice.db;
 
 public class Bot {
-    public String userId;
     public String token;
+    public String userId;
+    public String teamName;
+
+    public Bot() {
+
+    }
+
+    public Bot(String token, String userId, String teamName) {
+        this.token = token;
+        this.userId = userId;
+        this.teamName = teamName;
+    }
 }

--- a/app/org/catalyst/slackservice/db/RedisDbHandler.java
+++ b/app/org/catalyst/slackservice/db/RedisDbHandler.java
@@ -3,14 +3,12 @@ package org.catalyst.slackservice.db;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.catalyst.slackservice.services.AnalyticsKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 
 import javax.inject.Inject;
-import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
@@ -60,7 +58,7 @@ public class RedisDbHandler implements TokenHandler {
 
     @Override
     public void setBotInfo(String teamId, Bot bot) {
-        if (teamId == null || bot.userId == null || bot.token == null) {
+        if (teamId == null || bot.userId == null || bot.token == null || bot.teamName == null) {
             logger.error("set bot token failed. teamId: {}, botName: {}, token null ? {}", teamId, bot.userId, (bot.token == null));
             return;
         }

--- a/app/org/catalyst/slackservice/services/AnalyticsEvent.java
+++ b/app/org/catalyst/slackservice/services/AnalyticsEvent.java
@@ -18,12 +18,22 @@ public class AnalyticsEvent {
     private String category;
     private String action;
     private String label;
+    private String cd1;
+    private String cd2;
+    private String cd3;
+    private String cd4;
+    private String cd5;
 
     private AnalyticsEvent(AnalyticsKey key, String action) {
         this.trackingId = key.trackingId;
         this.userId = key.userId;
         this.category = key.channelId;
         this.action = action;
+        this.cd1 = key.teamName;
+        this.cd2 = key.teamId;
+        this.cd3 = key.channelId;
+        this.cd4 = key.userId;
+        this.cd5 = key.locale.getCode();
     }
 
     private AnalyticsEvent(AnalyticsKey key, String action, String label) {
@@ -40,6 +50,11 @@ public class AnalyticsEvent {
             put("ec", category);
             put("ea", action);
             put("el", label);
+            put("cd1", cd1);
+            put("cd2", cd2);
+            put("cd3", cd3);
+            put("cd4", cd4);
+            put("cd5", cd5);
         }};
     }
 

--- a/app/org/catalyst/slackservice/services/AnalyticsKey.java
+++ b/app/org/catalyst/slackservice/services/AnalyticsKey.java
@@ -1,14 +1,22 @@
 package org.catalyst.slackservice.services;
 
+import org.catalyst.slackservice.util.SlackLocale;
+
 public class AnalyticsKey {
     public String trackingId;
+    public String teamId;
+    public String teamName;
     public String channelId;
     public String userId;
+    public SlackLocale locale;
 
-    public AnalyticsKey(String trackingId, String channelId, String userId) {
+    public AnalyticsKey(String trackingId, String teamId, String teamName, String channelId, String userId, SlackLocale locale) {
         this.trackingId = trackingId;
+        this.teamId = teamId;
+        this.teamName = teamName;
         this.channelId = channelId;
         this.userId = userId;
+        this.locale = locale;
     }
 }
 

--- a/app/org/catalyst/slackservice/services/GoogleAnalyticsService.java
+++ b/app/org/catalyst/slackservice/services/GoogleAnalyticsService.java
@@ -27,6 +27,7 @@ public class GoogleAnalyticsService implements AnalyticsService {
          var request = _wsClient.url(uri.toString())
                  .addHeader("User-Agent", USER_AGENT);
          request = addQueryParameters(request, event.getMap()); // addQueryParameters will url encode the values
+
          request.post("");
       }
       catch(Exception e) {

--- a/test/org/catalyst/slackservice/controllers/AuthControllerTest.java
+++ b/test/org/catalyst/slackservice/controllers/AuthControllerTest.java
@@ -79,7 +79,10 @@ public class AuthControllerTest extends WithApplication {
         tokenKey.teamId = "TEAM234";
         tokenKey.userId = "USER123";
 
-        assertEquals("xoxb-token-234", dbManager.getBotInfo("TEAM234").token);
+        var botInfo = dbManager.getBotInfo("TEAM234");
+        assertEquals("xoxb-token-234", botInfo.token);
+        assertEquals("BOT123", botInfo.userId);
+        assertEquals("team-234", botInfo.teamName);
         assertEquals("xoxp-token-123", dbManager.getUserToken(tokenKey));
         assertEquals(FOUND, result.status());
     }

--- a/test/org/catalyst/slackservice/controllers/EventControllerTest.java
+++ b/test/org/catalyst/slackservice/controllers/EventControllerTest.java
@@ -6,6 +6,7 @@ import org.catalyst.slackservice.domain.SlackResponse;
 import org.catalyst.slackservice.services.*;
 import org.catalyst.slackservice.util.AppConfig;
 import org.catalyst.slackservice.util.MockConfig;
+import org.catalyst.slackservice.util.SlackLocale;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -44,9 +45,7 @@ public class EventControllerTest extends WithApplication {
         token.teamId = "TEAM123";
         mockDbHandler.setUserToken(token, "xoxp-1234");
 
-        Bot bot = new Bot();
-        bot.token = "xoxb-2345";
-        bot.userId = "BOT123";
+        Bot bot = new Bot("xoxb-2345", "BOT123", "team-123");
         mockDbHandler.setBotInfo("TEAM123", bot);
     }
 
@@ -207,7 +206,7 @@ public class EventControllerTest extends WithApplication {
         eventRequest.event.type = "message";
         eventRequest.event.text = "text";
         var expectedAnalyticsEvent = AnalyticsEvent.createMessageEvent(
-                new AnalyticsKey("UA-XXXX-Y", "valid_channel_123", "USER123"),
+                new AnalyticsKey("UA-XXXX-Y", "TEAM123", "team-123", "valid_channel_123", "USER123", new SlackLocale("en")),
                 "");
 
         var httpRequest = new Http.RequestBuilder()
@@ -229,7 +228,7 @@ public class EventControllerTest extends WithApplication {
         eventRequest.event.type = "message";
         eventRequest.event.text = "she's so quiet";
         var expectedAnalyticsEvent = AnalyticsEvent.createMessageEvent(
-                new AnalyticsKey("UA-XXXX-Y", "valid_channel_123", "USER123"),
+                new AnalyticsKey("UA-XXXX-Y", "TEAM123", "team-123", "valid_channel_123", "USER123", new SlackLocale("en")),
                 "correction");
 
         var httpRequest = new Http.RequestBuilder()
@@ -255,7 +254,7 @@ public class EventControllerTest extends WithApplication {
         eventRequest.event.text = "she's so quiet";
         eventRequest.event.user = "USER999";
         var expectedAnalyticsEvent = AnalyticsEvent.createMessageEvent(
-                new AnalyticsKey("UA-XXXX-Y", "valid_channel_123", "USER999"),
+                new AnalyticsKey("UA-XXXX-Y", "TEAM123", "team-123", "valid_channel_123", "USER999", new SlackLocale("en")),
                 "correction");
 
         var httpRequest = new Http.RequestBuilder()

--- a/test/org/catalyst/slackservice/controllers/HelpControllerTest.java
+++ b/test/org/catalyst/slackservice/controllers/HelpControllerTest.java
@@ -29,9 +29,7 @@ public class HelpControllerTest extends WithApplication {
 
     @Before
     public void setup() {
-        Bot bot = new Bot();
-        bot.token = "xoxb-2345";
-        bot.userId = "BOT123";
+        Bot bot = new Bot("xoxb-2345", "BOT123", "test");
         mockDbHandler.setBotInfo("TEAM123", bot);
     }
 

--- a/test/org/catalyst/slackservice/controllers/UserActionControllerTest.java
+++ b/test/org/catalyst/slackservice/controllers/UserActionControllerTest.java
@@ -4,6 +4,7 @@ import org.catalyst.slackservice.db.*;
 import org.catalyst.slackservice.domain.Action;
 import org.catalyst.slackservice.domain.InteractiveMessage;
 import org.catalyst.slackservice.services.*;
+import org.catalyst.slackservice.util.SlackLocale;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -45,9 +46,7 @@ public class UserActionControllerTest extends WithApplication {
 
     @Before
     public void setup() {
-        Bot bot = new Bot();
-        bot.token = "xoxb-2345";
-        bot.userId = "BOT123";
+        Bot bot = new Bot("xoxb-2345", "BOT123", "team-123");
         mockDbHandler.setBotInfo("TEAM123", bot);
     }
 
@@ -179,7 +178,7 @@ public class UserActionControllerTest extends WithApplication {
         requestBody.put("payload", payload);
 
         var expectedAnalyticsEvent = AnalyticsEvent.createMessageActionEvent(
-                new AnalyticsKey("UA-XXXX-Y", "CHANNEL123", "USER123"),
+                new AnalyticsKey("UA-XXXX-Y", "TEAM123", "team-123", "CHANNEL123", "USER123", new SlackLocale("en")),
                 new Action("Ignore", "Ignore", "no", "", "")
         );
 
@@ -229,7 +228,7 @@ public class UserActionControllerTest extends WithApplication {
         requestBody.put("payload", payload);
 
         var expectedAnalyticsEvent = AnalyticsEvent.createMessageActionEvent(
-                new AnalyticsKey("UA-XXXX-Y", "CHANNEL123", "USER123"),
+                new AnalyticsKey("UA-XXXX-Y", "TEAM123", "team-123", "CHANNEL123", "USER123", new SlackLocale("en")),
                 new Action("Learn More", "Learn More", "learn_more", "", "")
         );
 
@@ -261,7 +260,7 @@ public class UserActionControllerTest extends WithApplication {
         requestBody.put("payload", payload);
 
         var expectedAnalyticsEvent = AnalyticsEvent.createMessageActionEvent(
-                new AnalyticsKey("UA-XXXX-Y", "CHANNEL123", "USER123"),
+                new AnalyticsKey("UA-XXXX-Y", "TEAM123", "team-123", "CHANNEL123", "USER123", new SlackLocale("en")),
                 new Action("Bias Correct", "Bias Correct", "yes", "", "")
         );
 

--- a/test/org/catalyst/slackservice/db/RedisDbHandlerTest.java
+++ b/test/org/catalyst/slackservice/db/RedisDbHandlerTest.java
@@ -3,6 +3,7 @@ package org.catalyst.slackservice.db;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
@@ -10,14 +11,15 @@ import redis.clients.jedis.JedisPool;
 public class RedisDbHandlerTest {
 
     RedisDbHandler dbManager;
+    Jedis jedisMock;
 
     @Before
     public void setup() {
         var jedisPool = Mockito.mock(JedisPool.class);
-        var jedis = Mockito.mock(Jedis.class);
+        jedisMock = Mockito.mock(Jedis.class);
         dbManager = new RedisDbHandler(jedisPool);
-        Mockito.when(jedisPool.getResource()).thenReturn(jedis);
-        Mockito.when(jedis.hget("user_tokens", "TEAM123_USER123")).thenReturn("xoxp-token-1234");
+        Mockito.when(jedisPool.getResource()).thenReturn(jedisMock);
+        Mockito.when(jedisMock.hget("user_tokens", "TEAM123_USER123")).thenReturn("xoxp-token-1234");
     }
 
     @Test
@@ -51,4 +53,48 @@ public class RedisDbHandlerTest {
         }
     }
 
+    @Test
+    public void testSetBotInfoWithNullTeamId() {
+        var bot = new Bot("foo", "bar", "baz");
+
+        dbManager.setBotInfo(null, bot);
+
+        Mockito.verify(jedisMock, Mockito.times(0)).hset(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+    }
+
+    @Test
+    public void testSetBotInfoWithNullUserId() {
+        var bot = new Bot(null, "bar", "baz");
+
+        dbManager.setBotInfo("qux", bot);
+
+        Mockito.verify(jedisMock, Mockito.times(0)).hset(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+    }
+
+    @Test
+    public void testSetBotInfoWithNullToken() {
+        var bot = new Bot("foo", null, "baz");
+
+        dbManager.setBotInfo("qux", bot);
+
+        Mockito.verify(jedisMock, Mockito.times(0)).hset(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+    }
+
+    @Test
+    public void testSetBotInfoWithNullTeamName() {
+        var bot = new Bot("foo", "bar", null);
+
+        dbManager.setBotInfo("qux", bot);
+
+        Mockito.verify(jedisMock, Mockito.times(0)).hset(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+    }
+
+    @Test
+    public void testSetBotInfo() {
+        var bot = new Bot("foo", "bar", "baz");
+
+        dbManager.setBotInfo("qux", bot);
+
+        Mockito.verify(jedisMock, Mockito.times(1)).hset("bot_tokens", "qux", "{\"token\":\"foo\",\"userId\":\"bar\",\"teamName\":\"baz\"}");
+    }
 }

--- a/test/org/catalyst/slackservice/services/AnalyticsEventTest.java
+++ b/test/org/catalyst/slackservice/services/AnalyticsEventTest.java
@@ -1,6 +1,7 @@
 package org.catalyst.slackservice.services;
 
 import org.catalyst.slackservice.domain.Action;
+import org.catalyst.slackservice.util.SlackLocale;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.theories.DataPoints;
@@ -15,7 +16,7 @@ public class AnalyticsEventTest {
 
     @Test
     public void testBiasMatchCreateMessageEvent() {
-        var key = new AnalyticsKey("trackingId", "channelId", "userId");
+        var key = new AnalyticsKey("trackingId","teamId","teamName", "channelId", "userId", new SlackLocale("fr-FR"));;
         var trigger = "trigger";
 
         var expected = new HashMap<String, String>() {{
@@ -26,6 +27,11 @@ public class AnalyticsEventTest {
             put("ec", "channelId");
             put("ea", "Message - Bias Match");
             put("el", "");
+            put("cd1", "teamName");
+            put("cd2", "teamId");
+            put("cd3", "channelId");
+            put("cd4", "userId");
+            put("cd5", "fr-FR");
         }};
 
         var result = AnalyticsEvent.createMessageEvent(key, trigger).getMap();
@@ -39,7 +45,7 @@ public class AnalyticsEventTest {
     @Test
     @Theory
     public void testNoActionCreateMessageEvent(String trigger) {
-        var key = new AnalyticsKey("trackingId", "channelId", "userId");
+        var key = new AnalyticsKey("trackingId","teamId","teamName", "channelId", "userId", new SlackLocale("en-US"));
 
         var expected = new HashMap<String, String>() {{
             put("v", "1");
@@ -49,6 +55,11 @@ public class AnalyticsEventTest {
             put("ec", "channelId");
             put("ea", "Message - No Action");
             put("el", "");
+            put("cd1", "teamName");
+            put("cd2", "teamId");
+            put("cd3", "channelId");
+            put("cd4", "userId");
+            put("cd5", "en-US");
         }};
 
         var result = AnalyticsEvent.createMessageEvent(key, trigger).getMap();
@@ -58,7 +69,7 @@ public class AnalyticsEventTest {
 
     @Test
     public void testYesCreateMessageActionEvent() {
-        var key = new AnalyticsKey("trackingId", "channelId", "userId");
+        var key = new AnalyticsKey("trackingId","teamId","teamName", "channelId", "userId", new SlackLocale("fr-FR"));
         var action = new Action();
         action.value = Action.YES.toString();
 
@@ -70,6 +81,11 @@ public class AnalyticsEventTest {
             put("ec", "channelId");
             put("ea", "User - Applied Suggestion");
             put("el", "");
+            put("cd1", "teamName");
+            put("cd2", "teamId");
+            put("cd3", "channelId");
+            put("cd4", "userId");
+            put("cd5", "fr-FR");
         }};
 
         var result = AnalyticsEvent.createMessageActionEvent(key, action).getMap();
@@ -79,7 +95,7 @@ public class AnalyticsEventTest {
 
     @Test
     public void testNoCreateMessageActionEvent() {
-        var key = new AnalyticsKey("trackingId", "channelId", "userId");;
+        var key = new AnalyticsKey("trackingId","teamId","teamName", "channelId", "userId", new SlackLocale("en-US"));
         var action = new Action();
         action.value = Action.NO.toString();
 
@@ -91,6 +107,11 @@ public class AnalyticsEventTest {
             put("ec", "channelId");
             put("ea", "User - Rejected Suggestion");
             put("el", "");
+            put("cd1", "teamName");
+            put("cd2", "teamId");
+            put("cd3", "channelId");
+            put("cd4", "userId");
+            put("cd5", "en-US");
         }};
 
         var result = AnalyticsEvent.createMessageActionEvent(key, action).getMap();
@@ -100,7 +121,7 @@ public class AnalyticsEventTest {
 
     @Test
     public void testLearnMoreCreateMessageActionEvent() {
-        var key = new AnalyticsKey("trackingId", "channelId", "userId");
+        var key = new AnalyticsKey("trackingId","teamId","teamName", "channelId", "userId", new SlackLocale("en-US"));
         var action = new Action();
         action.value = Action.LEARN_MORE.toString();
 
@@ -112,6 +133,11 @@ public class AnalyticsEventTest {
             put("ec", "channelId");
             put("ea", "User - Clicked Learn More");
             put("el", "");
+            put("cd1", "teamName");
+            put("cd2", "teamId");
+            put("cd3", "channelId");
+            put("cd4", "userId");
+            put("cd5", "en-US");
         }};
 
         var result = AnalyticsEvent.createMessageActionEvent(key, action).getMap();
@@ -121,7 +147,7 @@ public class AnalyticsEventTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testInvalidCreateMessageActionEvent() {
-        var key = new AnalyticsKey("trackingId", "channelId", "userId");
+        var key = new AnalyticsKey("trackingId", "teamId", "TeamName","channelId", "userId", new SlackLocale("en-US"));
         var action = new Action(); // specify no value
 
         var expected = new HashMap<String, String>() {{
@@ -132,6 +158,11 @@ public class AnalyticsEventTest {
             put("ec", "channelId");
             put("ea", "User - Clicked Learn More");
             put("el", "");
+            put("cd1", "teamName");
+            put("cd2", "teamId");
+            put("cd3", "channelId");
+            put("cd4", "userId");
+            put("cd5", "en-US");
         }};
 
         var result = AnalyticsEvent.createMessageActionEvent(key, action);

--- a/test/org/catalyst/slackservice/services/AnalyticsEventTest.java
+++ b/test/org/catalyst/slackservice/services/AnalyticsEventTest.java
@@ -45,7 +45,7 @@ public class AnalyticsEventTest {
     @Test
     @Theory
     public void testNoActionCreateMessageEvent(String trigger) {
-        var key = new AnalyticsKey("trackingId","teamId","teamName", "channelId", "userId", new SlackLocale("en-US"));
+        var key = new AnalyticsKey("trackingId", "teamId", "teamName", "channelId", "userId", new SlackLocale("en-US"));
 
         var expected = new HashMap<String, String>() {{
             put("v", "1");
@@ -69,7 +69,7 @@ public class AnalyticsEventTest {
 
     @Test
     public void testYesCreateMessageActionEvent() {
-        var key = new AnalyticsKey("trackingId","teamId","teamName", "channelId", "userId", new SlackLocale("fr-FR"));
+        var key = new AnalyticsKey("trackingId", "teamId", "teamName", "channelId", "userId", new SlackLocale("fr-FR"));
         var action = new Action();
         action.value = Action.YES.toString();
 
@@ -95,7 +95,7 @@ public class AnalyticsEventTest {
 
     @Test
     public void testNoCreateMessageActionEvent() {
-        var key = new AnalyticsKey("trackingId","teamId","teamName", "channelId", "userId", new SlackLocale("en-US"));
+        var key = new AnalyticsKey("trackingId", "teamId", "teamName", "channelId", "userId", new SlackLocale("en-US"));
         var action = new Action();
         action.value = Action.NO.toString();
 
@@ -121,7 +121,7 @@ public class AnalyticsEventTest {
 
     @Test
     public void testLearnMoreCreateMessageActionEvent() {
-        var key = new AnalyticsKey("trackingId","teamId","teamName", "channelId", "userId", new SlackLocale("en-US"));
+        var key = new AnalyticsKey("trackingId", "teamId", "teamName", "channelId", "userId", new SlackLocale("en-US"));
         var action = new Action();
         action.value = Action.LEARN_MORE.toString();
 
@@ -147,7 +147,7 @@ public class AnalyticsEventTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testInvalidCreateMessageActionEvent() {
-        var key = new AnalyticsKey("trackingId", "teamId", "TeamName","channelId", "userId", new SlackLocale("en-US"));
+        var key = new AnalyticsKey("trackingId", "teamId", "teamName", "channelId", "userId", new SlackLocale("en-US"));
         var action = new Action(); // specify no value
 
         var expected = new HashMap<String, String>() {{

--- a/test/org/catalyst/slackservice/services/AnalyticsEventTest.java
+++ b/test/org/catalyst/slackservice/services/AnalyticsEventTest.java
@@ -16,7 +16,7 @@ public class AnalyticsEventTest {
 
     @Test
     public void testBiasMatchCreateMessageEvent() {
-        var key = new AnalyticsKey("trackingId","teamId","teamName", "channelId", "userId", new SlackLocale("fr-FR"));;
+        var key = new AnalyticsKey("trackingId", "teamId", "teamName", "channelId", "userId", new SlackLocale("fr-FR"));;
         var trigger = "trigger";
 
         var expected = new HashMap<String, String>() {{

--- a/test/org/catalyst/slackservice/services/GoogleAnalyticsServiceTest.java
+++ b/test/org/catalyst/slackservice/services/GoogleAnalyticsServiceTest.java
@@ -1,5 +1,6 @@
 package org.catalyst.slackservice.services;
 
+import org.catalyst.slackservice.util.SlackLocale;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -8,6 +9,7 @@ import play.libs.ws.WSClient;
 import play.libs.ws.WSRequest;
 
 import java.util.Arrays;
+import java.util.List;
 
 public class GoogleAnalyticsServiceTest {
 
@@ -19,7 +21,7 @@ public class GoogleAnalyticsServiceTest {
         Mockito.when(wsClientMock.url(Mockito.anyString())).thenReturn(wsRequestMock);
         Mockito.when(wsRequestMock.addHeader(Mockito.anyString(), Mockito.anyString())).thenReturn(wsRequestMock);
 
-        var key = new AnalyticsKey("trackingId", "channelId", "userId");
+        var key = new AnalyticsKey("trackingId", "teamId", "teamName", "channelId", "userId", new SlackLocale("en-US"));
         var trigger = "trigger";
         var event = AnalyticsEvent.createMessageEvent(key, trigger);
 
@@ -35,14 +37,43 @@ public class GoogleAnalyticsServiceTest {
 
         Mockito.verify(wsRequestMock, Mockito.times(1))
                 .addHeader(keyArgument.capture(), valueArgument.capture());
-        Mockito.verify(wsRequestMock, Mockito.times(7))
+        Mockito.verify(wsRequestMock, Mockito.times(12))
                 .addQueryParameter(keyArgument.capture(), valueArgument.capture());
 
-        Assert.assertEquals(keyArgument.getAllValues(),
-                Arrays.asList("User-Agent", "t", "v", "el", "ea", "tid", "ec", "cid"));
-        Assert.assertEquals(valueArgument.getAllValues(),
-                Arrays.asList("CatalystBiasCorrectService/1.0.1", "event", "1", "", "Message - Bias Match", "trackingId", "channelId", "userId"));
-
+        Assert.assertEquals(keyArgument.getAllValues(), expectedRequestKeys);
+        Assert.assertEquals(valueArgument.getAllValues(), expectedRequestValues);
         Mockito.verify(wsRequestMock, Mockito.times(1)).post("");
     }
+
+    private static List<String> expectedRequestKeys = Arrays.asList(
+        "User-Agent",
+        "cd2",
+        "cd1",
+        "cd4",
+        "cd3",
+        "t",
+        "cd5",
+        "v",
+        "el",
+        "ea",
+        "tid",
+        "ec",
+        "cid"
+    );
+
+    private static List<String> expectedRequestValues = Arrays.asList(
+        "CatalystBiasCorrectService/1.0.1",
+        "teamId",
+        "teamName",
+        "userId",
+        "channelId",
+        "event",
+        "en-US",
+        "1",
+        "",
+        "Message - Bias Match",
+        "trackingId",
+        "channelId",
+        "userId"
+    );
 }

--- a/test/org/catalyst/slackservice/services/MockSlackService.java
+++ b/test/org/catalyst/slackservice/services/MockSlackService.java
@@ -29,6 +29,7 @@ public class MockSlackService implements AppService {
             authResponse.ok = true;
             authResponse.team = new AuthResponse.Team();
             authResponse.team.id = "TEAM234";
+            authResponse.team.name = "team-234";
             authResponse.user = new AuthResponse.AuthedUser();
             authResponse.user.id = "USER123";
             authResponse.user.accessToken = "xoxp-token-123";

--- a/test/org/catalyst/slackservice/services/SlackServiceTest.java
+++ b/test/org/catalyst/slackservice/services/SlackServiceTest.java
@@ -40,9 +40,7 @@ public class SlackServiceTest {
     @Before
     public void setup() {
         config = new MockConfig();
-        bot = new Bot();
-        bot.userId = "BOT123";
-        bot.token = "xoxb-1234";
+        bot = new Bot("xoxb-2345", "BOT123", "test-123");
 
         Map<String, String> messagesMap = new HashMap<>();
         messagesMap.put("message.suggestion", "Suggested correction");


### PR DESCRIPTION
Add cd1-cd5 to pass custom data to google analytics. Some data is
duplicated but that is to allow easier filtering. The only piece
of data not readily available was teamName, to easily access this
data it has been added to the bot info object.

To view data in google analytics navigate to:
`Behavior > Events > Top Events > Select Secondary Dimension`