### PR TITLE
Feature: BGC-140 Dockerfile and sbt version update for builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# Dockerfile created to work with build.sh
+# unable to find a compatible docker image with jdk12 and sbt version 1.3.5
+
+ARG BASE_IMAGE_TAG
+FROM openjdk:${BASE_IMAGE_TAG:-12-jdk}
+
+ARG SBT_VERSION
+ENV SBT_VERSION ${SBT_VERSION:-1.3.5}
+
+RUN \
+  curl -L -o sbt-$SBT_VERSION.rpm https://bintray.com/sbt/rpm/download_file?file_path=sbt-$SBT_VERSION.rpm && \
+  rpm -i sbt-$SBT_VERSION.rpm && \
+  rm sbt-$SBT_VERSION.rpm && \
+  yum -y update && \
+  yum -y install sbt && \
+  sbt sbtVersion

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# for teamcity builds
+
+if [[ $# -eq 0 ]]
+  then
+    echo "invalid bias-correct url parameter"
+    exit 1
+fi
+
+url="$1/corrector/correct"
+echo "integration testing against bias-correct url = $url"
+
+docker build -t sbt135-jdk12 .
+docker run -it --rm -v $PWD:/app -w /app -e BIAS_CORRECT_URL=${url} sbt135-jdk12 sbt clean compile test

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.4
+sbt.version=1.3.5


### PR DESCRIPTION
- added dockerfile and build script for teamcity
- updated sbt version to address build error `object sbt is not a member of package com.typesafe import com.typesafe.sbt.packager.docker._`
