### PR TITLE
Feature: BGC-140 add latest tag for security scan docker image download

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,6 +33,7 @@ import com.typesafe.sbt.packager.docker._
 dockerPermissionStrategy := DockerPermissionStrategy.Run
 dockerVersion := Some(DockerVersion(18, 9, 0, Some("ce")))
 dockerRepository := sys.env.get("DOCKER_REPOSITORY")
+dockerUpdateLatest := true
 dockerBaseImage := "openjdk:12-alpine"
 dockerCommands ++= Seq(
   Cmd("USER", "root"),


### PR DESCRIPTION
This change will tag the latest docker image as 'latest' before it gets published to AWS ECR:
<img width="1100" alt="Screen Shot 2020-10-01 at 10 08 46 AM" src="https://user-images.githubusercontent.com/43787133/94820360-62c29e00-03ce-11eb-9025-ae72acee4dbc.png">

